### PR TITLE
add dependencies using opam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ Makefile.conf
 *.toc
 *.vrb
 *~
+
+# opam
+_opam

--- a/README.mdwn
+++ b/README.mdwn
@@ -2,31 +2,34 @@
 
 ## Setup
 
-You will need a version of Coq and various other tools supported by
-CompCert v3.6. If you are using `opam` (recommended),
-the following works as of 2020-03-06:
+1. Clone this project and its submodules,
+```bash
+git clone --recurse-submodules git@github.com:CertiKOS/rbgs.git
+```
 
-    $ opam init
-    $ opam install coq.8.9.1 menhir.20200211
+2. Create a local switch and install all dependencies using `opam`,
+```bash
+cd rbgs
+opam switch create ./
+```
 
-You can then clone the git repository using the following command:
-
-    $ git clone https://github.com/CertiKOS/rbgs.git
-
-Our `configure` script will take care of retreiving the git submodule
-for Coqrel and CompCertO, and will configure them:
-
-    $ cd rbgs
-    $ ./configure
-
+3. Load local switch into environment variables,
+```bash
+eval $(opam env)
+```
+4. Our `configure` script will take care of retreiving the git submodule
+   for Coqrel and CompCertO, and will configure them:
+```bash
+./configure
+```
 At this point make sure there were no error messages. In particular
 if your versions of Coq, Menhir, etc. are not suitable to build
 CompCert, this is when things will break.
 
-If the configuration was successful you should be able to build the
-development using `make`. We recommend using the `-jN` option to enable
-parallel jobs as CompCert will take a while to build otherwise.
-For example on my 8-cores machine:
-
-    $ make -j8
-
+5. If the configuration was successful you should be able to build the
+   development using `make`. We recommend using the `-jN` option to enable
+   parallel jobs as CompCert will take a while to build otherwise.
+   For example on my 8-cores machine:
+```bash
+make -j8
+```

--- a/rocq-rbgs.opam
+++ b/rocq-rbgs.opam
@@ -1,0 +1,12 @@
+opam-version: "2.0"
+homepage: "https://certikos.github.io/rbgs/html/toc.html"
+bug-reports: "https://github.com/CertiKOS/rbgs/issues"
+dev-repo: "git+https://github.com/CertiKOS/rbgs.git"
+version: "dev"
+
+synopsis: "Refinement-Based Game Semantics"
+depends: [
+  "coq" {= "8.15.1"}
+  "coq-iris" {= "4.0.0"}
+  "menhir"
+]


### PR DESCRIPTION
This PR introduces the `rocq-rbgs.opam` which handles all dependent external packages. `README.mdwn` is updated for the new setup process.